### PR TITLE
Fix MaticX : appears in Wallet

### DIFF
--- a/polygon/tokenlist.json
+++ b/polygon/tokenlist.json
@@ -3552,7 +3552,7 @@
     "symbol": "MaticX",
     "decimals": 18,
     "coingeckoId": "stader-maticx",
-    "wallet": true,
+    "wallet": false,
     "stable": false
   },
   {


### PR DESCRIPTION
Act as duplicate since it appears both in wallet + stader protocol instead of only stader

![image (3)](https://github.com/llamafolio/llamafolio-tokens/assets/110820448/484ba07c-a97b-4913-a336-7b22e77295e2)
